### PR TITLE
Various Fixes

### DIFF
--- a/include/nexus.hpp
+++ b/include/nexus.hpp
@@ -24,6 +24,7 @@ class Nexus {
 
         std::vector<int> spectra;
         int* rawFrames;
+        int goodFrames;
         int startSinceEpoch;
         int endSinceEpoch;
 
@@ -40,15 +41,14 @@ class Nexus {
         bool createHistogram(Pulse &pulse, int epochOffset=0);
         bool createHistogram(Pulse &pulse, std::map<unsigned int, gsl_histogram*> &mask, int epochOffset=0);
         bool output(std::vector<std::string> paths);
-        bool output(std::vector<std::string> paths, int numFrames, int rawFrames, std::map<int, std::vector<int>> monitors);
         bool copy();
         bool copy(H5::H5File in, H5::H5File out, std::vector<std::string> paths);
         bool writeCounts(H5::H5File output);
         bool writeTotalFrames(H5::H5File output, int frames);
         bool writeGoodFrames(H5::H5File output, int goodFrames);
+        bool reduceMonitors(double scale);
         bool writeMonitors(H5::H5File output, std::map<int, std::vector<int>> monitors);
         bool writePartitionsWithRelativeTimes(unsigned int lowerSpec, unsigned int upperSpec);
-        int countGoodFrames(Pulse &pulse, int epochOffset=0);
 
 };
 

--- a/include/nexus.hpp
+++ b/include/nexus.hpp
@@ -41,6 +41,7 @@ class Nexus {
         bool createHistogram(Pulse &pulse, std::map<unsigned int, gsl_histogram*> &mask, int epochOffset=0);
         bool output(std::vector<std::string> paths);
         bool output(std::vector<std::string> paths, int numFrames, int rawFrames, std::map<int, std::vector<int>> monitors);
+        bool copy();
         bool copy(H5::H5File in, H5::H5File out, std::vector<std::string> paths);
         bool writeCounts(H5::H5File output);
         bool writeTotalFrames(H5::H5File output, int frames);

--- a/src/modex.cpp
+++ b/src/modex.cpp
@@ -38,7 +38,6 @@ bool ModEx::process() {
 
 bool ModEx::processPulse(Pulse &pulse) {
     if (pulse.startRun == pulse.endRun) {
-        return false;
         std::string outpath = cfg.outputDir + "/" + std::to_string((int) pulse.start) + ".nxs";
         Nexus nxs = Nexus(pulse.startRun, outpath);
         if (!nxs.load(true))

--- a/src/modex.cpp
+++ b/src/modex.cpp
@@ -44,7 +44,15 @@ bool ModEx::processPulse(Pulse &pulse) {
             return false;
         if (!nxs.createHistogram(pulse, nxs.startSinceEpoch))
             return false;
-        if (!nxs.output(cfg.nxsDefinitionPaths))
+        int goodFrames = nxs.countGoodFrames(pulse, nxs.startSinceEpoch);
+        double ratio = (double) goodFrames /  (double) nxs.rawFrames[0];
+        std::map<int, std::vector<int>> monitors = nxs.monitors;
+        for (auto &pair : monitors) {
+            for (int i=0; i<pair.second.size(); ++i) {
+                pair.second[i]= (int) (pair.second[i] * ratio);
+            }
+        }
+        if (!nxs.output(cfg.nxsDefinitionPaths, nxs.rawFrames[0], goodFrames, monitors))
             return false;
         std::cout << "Finished processing: " << outpath << std::endl;
         return true;

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -250,22 +250,27 @@ int Nexus::countGoodFrames(Pulse &pulse, int epochOffset) {
 
 }
 
-bool Nexus::output(std::vector<std::string> paths) {
+bool Nexus::output(std::vector<std::string> paths, int rawFrames, int goodFrames, std::map<int, std::vector<int>> monitors) {
 
     try {
-        // Open Nexus file in read only mode.
-        H5::H5File input = H5::H5File(path, H5F_ACC_RDONLY);
+        if (!Nexus::copy()) {
+            return false;
+        }
+        // // Open Nexus file in read only mode.
+        // H5::H5File input = H5::H5File(path, H5F_ACC_RDONLY);
         
         // Create new Nexus file for output.
-        H5::H5File output = H5::H5File(outpath, H5F_ACC_TRUNC);
+        H5::H5File output = H5::H5File(outpath, H5F_ACC_RDWR);
 
-        // Perform copying.
-        if (!Nexus::copy(input, output, paths))
-            return false;
+        // // Perform copying.
+        // if (!Nexus::copy(input, output, paths))
+        //     return false;
 
-        input.close();
+        // input.close();
 
         writeCounts(output);
+        writeMonitors(output, monitors);
+        writeGoodFrames(output, goodFrames);
         output.close();
         return true;
 
@@ -275,32 +280,41 @@ bool Nexus::output(std::vector<std::string> paths) {
 
 }
 
-bool Nexus::output(std::vector<std::string> paths, int numFrames, int goodFrames, std::map<int, std::vector<int>> monitors) {
+// bool Nexus::output(std::vector<std::string> paths, int numFrames, int goodFrames, std::map<int, std::vector<int>> monitors) {
 
-    try {
-        // Open Nexus file in read only mode.
-        H5::H5File input = H5::H5File(path, H5F_ACC_RDONLY);
+//     try {
+//         // Open Nexus file in read only mode.
+//         H5::H5File input = H5::H5File(path, H5F_ACC_RDONLY);
         
-        // Create new Nexus file for output.
-        H5::H5File output = H5::H5File(outpath, H5F_ACC_TRUNC);
+//         // Create new Nexus file for output.
+//         H5::H5File output = H5::H5File(outpath, H5F_ACC_TRUNC);
 
-        // Perform copying.
-        if (!Nexus::copy(input, output, paths))
-            return false;
+//         // Perform copying.
+//         if (!Nexus::copy(input, output, paths))
+//             return false;
 
-        input.close();
+//         input.close();
 
-        writeCounts(output);
-        // writeTotalFrames(output, numFrames);
-        writeGoodFrames(output, goodFrames);
-        writeMonitors(output, monitors);
-        output.close();
-        return true;
+//         writeCounts(output);
+//         // writeTotalFrames(output, numFrames);
+//         writeGoodFrames(output, goodFrames);
+//         writeMonitors(output, monitors);
+//         output.close();
+//         return true;
 
-    } catch (...) {
-        return false;
-    }
+//     } catch (...) {
+//         return false;
+//     }
 
+// }
+
+bool Nexus::copy() {
+    std::ifstream src(path, std::ios::binary);
+    std::ofstream dest(outpath, std::ios::binary);
+    dest  << src.rdbuf();
+    src.close();
+    dest.close();
+    return true;
 }
 
 bool Nexus::copy(H5::H5File input, H5::H5File output, std::vector<std::string> paths) {


### PR DESCRIPTION
This PR fixes various issues that have been noticed within ModEx. Particulary related to the modulation excitation pipeline.
In particular, incorrect histograms were being outputted (now events are selected by looking at frames rather than individual events).

Minimisation of Nexus files has been implemented - closes #1.
Pulses between runs seems to be working (although needs to be tested, so I'm keeping #2 open for now).

Strange results were being produced from `gudrun_dcs` when using the outputted NeXus files from `modulation_excitation`, however now they look more like we would expect them to.