### PR TITLE
Update Config

### DIFF
--- a/include/pulse.hpp
+++ b/include/pulse.hpp
@@ -10,6 +10,7 @@ class Pulse {
         std::string startRun;
         std::string endRun;
         Pulse(std::string label_, double start_, double end_) : label(label_), start(start_), end(end_) {}
+        Pulse(double start_, double end_) : start(start_), end(end_) {}
         Pulse() = default;
 
 };

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -117,15 +117,8 @@ bool Config::parse() {
             }
             
             std::stringstream ss(line); // String stream for parsing.
-            std::string label;
             double pulseStart, pulseEnd;
             std::string item; // Auxilliary variable to read into.
-            
-            // Read in label.
-            if(!std::getline(ss, label, ' ')) {
-                std::cerr << "ERROR: couldn't retrieve label from pulse " << i << "." << std::endl;
-                return false;
-            }
 
             // Read in pulse start time.
             if(!std::getline(ss, item, ' ')) {
@@ -142,7 +135,7 @@ bool Config::parse() {
             pulseEnd = atof(item.c_str());
 
             // Append pulse.
-            pulses.push_back(Pulse(label, pulseStart, pulseEnd));
+            pulses.push_back(Pulse(pulseStart, pulseEnd));
         }
     } else { // Otherwise expect period definition.
 


### PR DESCRIPTION
Small PR to stop `ModEx::Config`expecting a `label` with raw pulses.